### PR TITLE
Fixed Berksfile to get rid of DEPRECATED warning

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-site :opscode
+source "https://supermarket.getchef.com"
 
 metadata
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following cookbooks are dependencies:
 * tomcat
 * nginx
 * artifact (Riot Games)
+* logrotate
 
 ## Platform:
 
@@ -50,6 +51,9 @@ UI header.
 * `node['ice']['processor']['enabled']` - Enables the Ice processor.
 * `node['ice']['processor']['local_dir']` - Local work directory for the Ice
 processor.
+* `node['ice']['processor']['issue_100_workaround']` - Optional. Work around 
+https://github.com/Netflix/ice/issues/100 by pre-creating the directories it 
+expects to find. Default: false
 * `node['ice']['billing_aws_access_key_id']` - AWS access key id used for
 accessing AWS detailed billing files from S3.
 * `node['ice']['billing_secret_key']` - AWS secret key used for
@@ -80,9 +84,47 @@ template name.  Default: 'nginx_ice_site.erb'.
 cookbook.  Use this if you'd like to bypass the default ice cookbook nginx 
 configuration and implement your own templates and recipes to configure Nginx for
 ice.  Default: 'ice'.
+* `node['ice']['nginx_default_server']` - Optional. Whether nginx should route all
+requests to Tomcat, regardless of Host: header.  Default: false.
 * `node['ice']['custom_resource_tags']` - Optional.  Array of custom resource tags
 to have ice process.  As described in the ice README you must explicitly enable these
 custom tags in your billing statements.
+* `node['ice']['reservation_capacity_poller_roles']` - Optional. Hash mapping 
+accounts to IAM roles in order to allow reservations in that account to be 
+polled.
+* `node['ice']['reservation_capacity_poller_external_ids']` - Optional. Hash mapping
+accounts to External IDs in order to allow reservations in that account to be
+polled.
+* `node['ice']['currencySign']` - Optional. Currency sign to use in place of $
+* `node['ice']['currencyRate']` - Optional. Conversion rate of USD to the above 
+currency. For example, if 1 pound = 1.5 dollar, then the rate is 0.6666667.
+* `node['ice']['highstockUrl']` - Optional. URL to highstock.js if you need to 
+serve this over HTTPS (which the default Highstock CDN does not currently support)
+* `node['ice']['monthlycachesize']` - Optional. Monthly cache size. 
+* `node['ice']['cost_per_monitormetric_per_hour']` - Optional. Cost per monitor 
+metric per hour. 
+* `node['ice']['urlPrefix']` - Optional. URL of Ice installation, used to create
+links in alert emails.
+* `node['ice']['fromEmail']` - Optional. Email address from which Ice email 
+alerts are sent (must be registered in SES)
+* `node['ice']['ondemandCostAlertThreshold']` - Optional. EC2 On-Demand hourly 
+cost threshold at which an alert email should be sent.
+* `node['ice']['ondemandCostAlertEmails']` - Optional. Comma-separated list of 
+recipients for the On-Demand cost alert emails.
+* `node['ice']['resourceGroupCost']` - Optional. If set to `original`, Ice will 
+use the original costs from the billing file for Resource Groups.
+* `node['ice']['weeklyCostEmails']` - Optional. Set to `true` to enable weekly 
+cost emails.
+* `node['ice']['weeklyCostEmails_fromEmail']` - Optional. Email address from
+which weekly cost emails are sent (must be registered in SES)
+* `node['ice']['weeklyCostEmails_bccEmail']` - Optional. Email address to which
+weekly cost emails will be BCCed.
+* `node['ice']['weeklyCostEmails_numWeeks']` - Optional. How many weeks to
+include in the weekly cost emails
+* `node['ice']['logrotate_frequency']` - Optional. How often to rotate catalina.out.
+Default: 'weekly'
+* `node['ice']['logrotate_rotate']` - Optional. How many rotated copies of
+catalina.out to keep. Default: 52
 
 ## Usage
 
@@ -159,6 +201,7 @@ run_list:
 * Contributor: [Benton Roberts](https://github.com/benton)
 * Contributor: [Harry Wilkinson](https://github.com/harryw)
 * Contributor: [rampire](https://github.com/rampire)
+* Contributor: [Alex Greg](https://github.com/agreg)
 
 Copyright 2013 Medidata Solutions Worldwide
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,6 +8,7 @@ node.default['ice']['company_name']                         = nil
 
 node.default['ice']['processor']['enabled']                 = true
 node.default['ice']['processor']['local_dir']                = '/var/ice_processor'
+node.default['ice']['processor']['issue_100_workaround']    = false
 
 # S3 keys for accessing billing files
 node.default['ice']['billing_aws_access_key_id']            = nil
@@ -41,9 +42,29 @@ node.default['ice']['reservation_period']                   = 'threeyear'
 # # reservation utilization, possible values are LIGHT, HEAVY
 node.default['ice']['reservation_utilization']               = 'HEAVY'
 
+node.default['ice']['currencySign']                          = nil
+node.default['ice']['currencyRate']                          = nil
+node.default['ice']['highstockUrl']                          = nil
+node.default['ice']['monthlycachesize']                      = nil
+node.default['ice']['cost_per_monitormetric_per_hour']       = nil
+node.default['ice']['urlPrefix']                             = nil
+node.default['ice']['fromEmail']                             = nil
+node.default['ice']['ondemandCostAlertThreshold']            = nil
+node.default['ice']['ondemandCostAlertEmails']               = nil
+node.default['ice']['resourceGroupCost']                     = nil
+node.default['ice']['weeklyCostEmails']                      = nil
+node.default['ice']['weeklyCostEmails_fromEmail']            = nil
+node.default['ice']['weeklyCostEmails_bccEmail']             = nil
+node.default['ice']['weeklyCostEmails_numWeeks']             = nil
+
 # This hostname is used for the nginx reverse proxy configuration
 node.default['ice']['public_hostname']                      = nil
 
 node.default['ice']['nginx_port']                           = 80
 node.default['ice']['nginx_config']                         = 'nginx_ice_site.erb'
 node.default['ice']['nginx_config_cookbook']                = 'ice'
+node.default['ice']['nginx_default_server']                 = false
+
+# Logrotate options for catalina.out
+node.default['ice']['logrotate_frequency']                  = 'weekly'
+node.default['ice']['logrotate_rotate']                     = 52

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,8 @@
     "tomcat": ">= 0.0.0",
     "nginx": ">= 0.0.0",
     "openssl": ">= 0.0.0",
-    "artifact": ">= 0.0.0"
+    "artifact": ">= 0.0.0",
+    "logrotate": ">= 0.0.0"
   },
   "recommendations": {
   },

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ version          '0.2.13'
 end
 
 # Cookbook dependencies
-%w{ java apt nginx openssl }.each do |cb|
+%w{ java apt nginx openssl logrotate }.each do |cb|
   depends cb
 end
 

--- a/templates/default/ice.properties.erb
+++ b/templates/default/ice.properties.erb
@@ -30,9 +30,21 @@ ice.startmillis=<%= node['ice']['start_millis'] %>
 ice.account.<%= account[0] %>=<%= account[1] %>
 <% end %>
 
-<% if node['ice']['owner_account'] && node['ice']['linked_accounts'].any? %>
+<% if node['ice']['owner_account'] && !node['ice']['linked_accounts'].nil? && node['ice']['linked_accounts'].any? %>
 ice.owneraccount.<%= node['ice']['owner_account'] %>=<%= node['ice']['linked_accounts'].join(',') %>
 <% end %>
+
+<%
+{"reservation_capacity_poller_roles" => "role", "reservation_capacity_poller_external_ids" => "externalId"}.each do |k,v|
+  if node['ice']['owner_account'] && !node['ice'][k].nil? && node['ice'][k].any?
+    node['ice'][k].each do |a,b|
+%>
+ice.owneraccount.<%= a %>.<%= v %>=<%= b %>
+<%
+end
+end
+end
+%>
 
 ice.reservationCapacityPoller=<%= node['ice']['reservation_capacity_poller'] %>
 
@@ -47,4 +59,10 @@ ice.companyName=<%= node['ice']['company_name'] %>
 ice.customTags=<%= node['ice']['custom_resource_tags'].join(',') %>
 <% end %>
 
-
+<% ['currencySign','currencyRate','highstockUrl','monthlycachesize','cost_per_monitormetric_per_hour','urlPrefix','fromEmail','ondemandCostAlertThreshold','ondemandCostAlertEmails','resourceGroupCost','weeklyCostEmails','weeklyCostEmails_fromEmail','weeklyCostEmails_bccEmail','weeklyCostEmails_numWeeks'].each do |prop|
+  if !node['ice'][prop].nil? %>
+ice.<%= prop %>=<%= node['ice'][prop] %>
+<%
+end
+end
+%>

--- a/templates/default/nginx_ice_site.erb
+++ b/templates/default/nginx_ice_site.erb
@@ -1,5 +1,5 @@
 server {
-  listen   <%= node['ice']['nginx_port'] %>;
+  listen   <%= node['ice']['nginx_port'] %><%= node['ice']['nginx_default_server'] == true ? " default_server" : '' %>;
 
   root <%= "#{node['tomcat']['webapp_dir']}/current" %>;
 


### PR DESCRIPTION
Work around https://github.com/Netflix/ice/issues/100 by pre-creating the directories it expects to find
Added nginx_default_server attribute to make Nginx proxy all HTTP requests to Tomcat
Added reservation_capacity_poller_roles and reservation_capacity_poller_external_ids attributes to define per-account IAM roles and external ids to allow polling of reservation capacity in different accounts
Added logrotate_frequency and logrotate_rotate attributes to define log rotation frequency and retention for catalina.out
Added attributes for the remaining options in ice.properties