### PR TITLE
Disable nginx default site

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -124,7 +124,9 @@ if node['ice']['reader']['enabled'] == true
   end
 
   # Disable default site first
-  nginx_site 'default', enable: false
+  nginx_site 'default' do
+    enable false
+  end
 
   # Generate nginx ice site
   template "#{node['nginx']['dir']}/sites-available/ice" do


### PR DESCRIPTION
The previous line #127 was not working in my environment - perhaps it is shorthand style that has been deprecated? 
